### PR TITLE
Add custom 404 landing page

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+        <title>Page not found | willsab.com</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <link rel="stylesheet" href="style.css">
+        <link rel="icon" type="image/x-icon" href="../images/favicon.ico">
+</head>
+<body>
+        <header>
+                <nav>
+                        <a href="/">Home</a>
+                        <a href="/about.html">About</a>
+                        <a href="/blog">Blog</a>
+                        <a href="/reading-list.html">Reading list</a>
+                </nav>
+        </header>
+
+        <main>
+                <h1>404: This page wandered off</h1>
+                <p>Sorry, I can't find the page you're looking for.</p>
+                <p>Maybe head back <a href="/">home</a> or explore the <a href="/blog">blog</a> instead?</p>
+        </main>
+
+        <footer>
+                <nav>
+                        <a href="https://twitter.com/willsab" target="_blank">Twitter</a>
+                        <a href="https://www.linkedin.com/in/willsab/" target="_blank">LinkedIn</a>
+                        <a href="https://github.com/wsaborio" target="_blank">GitHub</a>
+                        <a href="mailto:w@willsab.com">Email</a>
+                </nav>
+        </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a dedicated 404.html that matches the site navigation and footer
- guide lost visitors back to the home page or blog with friendly messaging

## Testing
- no automated tests were run (static site change)


------
https://chatgpt.com/codex/tasks/task_i_68deaa3c85648326b401b21d37f4f4d3