### PR TITLE
Update reading list: add 'Apprentice to Genius' and set current book to 'Cable Cowboy'

### DIFF
--- a/reading-list.html
+++ b/reading-list.html
@@ -28,11 +28,12 @@
 	<main>
 		<h3>Currently reading</h3>
 		<ul>
-			<li>Insisting on the Impossible: The Life of Edwin Land by Victor K. McElheny</li>
+			<li>Cable Cowboy by Mark Robichaux</li>
 		</ul>
 
 		<h3>Recently read</h3>
 		<ul>
+			<li>Apprentice to Genius by Robert Kanigel</li>
 			<li>Founders at Work by Jessica Livingston</li>
 			<li>Gambling Man: The Secret Story of the World's Greatest Disruptor, Masayoshi Son by Lionel Barber</li>
 			<li>Softwar: An Intimate Portrait of Larry Ellison and Oracle by Matthew Symonds</li>


### PR DESCRIPTION
### Motivation
- Update the site's reading list to reflect the current book and a recently finished book.
- Keep the static `reading-list.html` content accurate and up to date.

### Description
- Replace the "Currently reading" entry with `Cable Cowboy by Mark Robichaux` in `reading-list.html`.
- Add `Apprentice to Genius by Robert Kanigel` to the "Recently read" list in `reading-list.html`.
- Only the static file `reading-list.html` was modified.

### Testing
- No automated tests were run because this is a static content change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695455792ed88322be7f7c5d1492afe2)