### PR TITLE
Update reading list: add 'Cable Cowboy', move 'Prince of Persia', remove 'Project Hail Mary'

### DIFF
--- a/reading-list.html
+++ b/reading-list.html
@@ -28,11 +28,12 @@
 	<main>
 		<h3>Currently reading</h3>
 		<ul>
-			<li>The Making of Prince of Persia by Jordan Mechner</li>
+			<li>Cable Cowboy: John Malone and the Rise of the Modern Cable Business by Mark Robichaux</li>
 		</ul>
 
 		<h3>Recently read</h3>
 		<ul>
+			<li>The Making of Prince of Persia by Jordan Mechner</li>
 			<li>Apprentice to Genius by Robert Kanigel</li>
 			<li>Founders at Work by Jessica Livingston</li>
 			<li>Gambling Man: The Secret Story of the World's Greatest Disruptor, Masayoshi Son by Lionel Barber</li>
@@ -42,7 +43,6 @@
 			<li>Superintelligence: Paths, Dangers, Strategies by Nick Bostrom</li>
 			<li>Pieces of the Action by Vannevar Bush</li>
 			<li>Chip War by Chris Miller</li>
-			<li>Project Hail Mary by Andy Weir</li>
 			<li>The Hitchhiker's Guide to the Galaxy by Douglas Adams</li>
 			<li>The Shape of Design by Frank Chimero</li>
 			<li>Tomorrow, and Tomorrow, and Tomorrow by Gabrielle Zevin</li>


### PR DESCRIPTION
### Motivation
- Reflect updated reading statuses by marking "The Making of Prince of Persia" as recently read, removing "Project Hail Mary", and starting "Cable Cowboy" as currently reading.

### Description
- Edit `reading-list.html` to replace the `Currently reading` entry with `Cable Cowboy: John Malone and the Rise of the Modern Cable Business by Mark Robichaux`, add `The Making of Prince of Persia by Jordan Mechner` into the `Recently read` section, and remove `Project Hail Mary by Andy Weir` from the list.

### Testing
- Verified the updates with `git diff -- reading-list.html`, `rg -n "Cable Cowboy|Making of Prince of Persia|Project Hail Mary" reading-list.html`, and inspected the file with `nl -ba reading-list.html`, and attempted a Playwright screenshot which failed due to a Chromium SIGSEGV in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_i_698e6bb438548332b9b4b74aae8ade9f)